### PR TITLE
Move page#s from scan URLs to comments, remove no longer needed ignore file

### DIFF
--- a/se-lint-ignore.xml
+++ b/se-lint-ignore.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<se-lint-ignore>
-	<file path="content.opf">
-		<ignore>
-			<code>m-007</code>
-			<reason>Page scans link to pages in which the stories occur.</reason>
-		</ignore>
-	</file>
-</se-lint-ignore>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -57,12 +57,12 @@
 		</meta>
 		<dc:language>en-US</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/70652</dc:source>
-		<!-- Chapters I-III-->
-		<dc:source>https://archive.org/details/Astounding_v16n06_1936-02_frankenscan/page/n9</dc:source>
-		<!-- Chapters IV-VIII-->
-		<dc:source>https://archive.org/details/Astounding_v17n01_1936-03/page/n126</dc:source>
-		<!-- Chapters IX-XII-->
-		<dc:source>https://archive.org/details/Astounding_v17n02_1936-04/page/n132</dc:source>
+		<!-- Chapters I-III, p. 9 -->
+		<dc:source>https://archive.org/details/Astounding_v16n06_1936-02_frankenscan</dc:source>
+		<!-- Chapters IV-VIII, p. 126 -->
+		<dc:source>https://archive.org/details/Astounding_v17n01_1936-03</dc:source>
+		<!-- Chapters IX-XII, p. 132 -->
+		<dc:source>https://archive.org/details/Astounding_v17n02_1936-04</dc:source>
 		<meta property="se:word-count">40141</meta>
 		<meta property="se:reading-ease.flesch">42.04</meta>
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/At_the_Mountains_of_Madness</meta>


### PR DESCRIPTION
I could change the other ones directly, but I can't delete a file in the github.dev interface (right-click menu doesn't work), so I had to fork this one and submit a PR.

I believe this is the last one that had page#s in the scan URL's (two Lovecrafts, another short collection (Mack Reynolds), and a poetry collection). I'll do a PR in the next day or two for the review steps to add something for this, since all four got past two levels of review.